### PR TITLE
added placeholder instead of broken image in the product catalog

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={"/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
#3 
added placeholder instead of broken image in the product catalog
issue fixed
![image](https://user-images.githubusercontent.com/49144754/191102683-654bb78d-3f7b-4658-8e3d-adf83089797e.png)